### PR TITLE
Add github action for documentation pullrequests

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,23 @@
+name: CI for mdbook build
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install mdbook
+      run: |
+        mkdir mdbook
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.15/mdbook-v0.4.15-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        echo `pwd`/mdbook >> $GITHUB_PATH
+
+    - name: Create mdBook page
+      run: mdbook build


### PR DESCRIPTION
Add CI which runs on pull-requests and doesn't publish the build result to github pages.